### PR TITLE
add extra check to prevent empty _cdata attribute

### DIFF
--- a/src/Logic/CatalogExport/CatalogBuilder.php
+++ b/src/Logic/CatalogExport/CatalogBuilder.php
@@ -970,7 +970,7 @@ class CatalogBuilder
             foreach ($this->languages as $language) {
                 $fieldLocaleExport[] = [
                     '_attributes' => ['language' => $language],
-                    '_cdata'      =>  $fieldInfo['label'] ?? $fieldName,
+                    '_cdata'      =>  isset($fieldInfo['label']) && !empty($fieldInfo['label']) ? $fieldInfo['label'] : $fieldName
                 ];
             }
 


### PR DESCRIPTION
I added an extra check in the get_fields method to prevent an empty _cdata change. It would be nice if this could me merged into the plugin.